### PR TITLE
Fix vsi support in gdal-driver

### DIFF
--- a/src/osgEarth/GDAL.cpp
+++ b/src/osgEarth/GDAL.cpp
@@ -480,7 +480,7 @@ GDAL::Driver::open(
     {
         std::string input;
 
-        if (gdalOptions().url().isSet())
+        if (gdalOptions().url().isSet() && source.empty())
             input = gdalOptions().url()->full();
         else
             input = source;


### PR DESCRIPTION
The parsing for vsi-path is ignored, ie "source"-string is ignored.